### PR TITLE
Rclone uploads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,10 @@
 TOKEN=(token)
 MAX_DURATION=180
+
+
+USE_RCLONE=no
+RCLONE_REMOTE_NAME=googledrive:/
+USE_RCLONE_LINK=yes
+
+
+CUSTOM_LINK=https://example.com/clips/

--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,5 @@ cython_debug/
 keys.json
 yt-dlp.exe
 ffmpeg.exe
+rclone.1
+rclone.exe

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Discord YouTube Live Clipping Bot
 
-A simple Discord clipping bot for YouTube livestreams. The clip is uploaded to the Discord CDN (and if it doesn't fit under 25MB, it's compressed and then uploaded. rclone uploads are planned)
+A simple Discord clipping bot for YouTube livestreams. The clip is either:
+- uploaded to the Discord CDN (if it's below 25MB),
+- compressed and uploaded to the Discord CDN (if above 25MB),
+- or uploaded to an [rclone destination](https://rclone.org/overview/) and the link for it shared to Discord (also if above 25MB, this is not default and has to be optionally set up).
 
 # Demo
 
@@ -18,9 +21,9 @@ https://github.com/user-attachments/assets/a48e28f3-11fc-4cc6-ae3e-c14dd7167597
 # Setup
 0. Make sure you have all the requirements installed.
 > [!NOTE]
-> For Windows users, please check if Python is in PATH. And make sure to run Python correctly as most times it's `py` or `python3` instead of `python`. In this guide, This will be referred to as `python` at the start of the command.
+> For Windows users, please check if Python is in PATH. And make sure to run Python correctly as most times it's `py` or `python` instead of `python3` (at least on Windows systems). In this guide, this will be referred to as `python` at the start of the command.
 1. Git Clone/Download the repository as a .zip and extract it.
-2. <span style="font-size:1.5rem;font-weight:900">If you don't know what a bot token is, follow the guide in [Add Bot Readme File](/ADD-BOT.md) </span>
+2. <span style="font-size:1.5rem;font-weight:900">If you don't know what a bot token is, follow the guide in [Add Bot Readme File](/ADD-BOT.md). </span>
 If you do, create a bot at the [Discord Developer Portal](https://discord.com/developers/applications).
 > [!IMPORTANT]
 > Do NOT forget to turn on "Message Content Intent" and in the Bot settings and "Application Command" scope in OAuth2 settings.
@@ -33,7 +36,33 @@ If you do, create a bot at the [Discord Developer Portal](https://discord.com/de
 5. The program will create a `.env` file in the same directory as the bot. Add your bot token to the file replacing the "(token)". Also, set maximum duration of the clip in seconds (default is 180 seconds), should you want to change it.
 > [!NOTE]
 > If you followed the guide, it's the thing you copied after you reset token.
-6. Run `python bot.py` again. The bot should ne up and running now.
-
+6. Run `python bot.py` again. The bot should be up and running now.
+> 
 # NOTICE
 If you don't see any slash commands, ~~blame discord for making this system so dumb~~ run "!sync" in your server. When the bot responds with "Synced 1 commands globally", you should be able to see them now. If not, restart your client. If not, try running the command again.
+
+# Rclone setup
+On some low-end systems and in some scenarios, compression can be a dealbreaker, whether it's because of the speed or for the sake of preserving quality. This is why the bot supports [rclone](https://rclone.org/overview/), so instead of uploading the clip to Discord, it uploads to an rclone destination and shares a link to the file.
+The usage of rclone is optional - if it isn't set up, the bot defaults to using compression.
+## Requirements
+- [rclone](https://rclone.org/downloads/) in PATH
+- Either a remote already added, or if you're copying it to a local directory (e.g if you're hosting an HTTP server on the same machine) the folder where all of your clips will reside
+1. Open the .env file. Here you'll be entering your rclone configuration:
+   
+![image](https://github.com/user-attachments/assets/a335c650-a3c9-43e9-9bbb-e25e70da2e2f)
+
+2. Set `USE_RCLONE` to `yes`
+3. Set `RCLONE_REMOTE_NAME` to either:
+   - the name of your remote, appended with `:/`
+   - the folder of your HTTP server where your clips will reside
+     
+![oltO6mQ2Rn](https://github.com/user-attachments/assets/0eba5cee-9a37-4dab-87f3-ef8ce0b80ff6)
+
+4. If you're uploading to a simple remote (e.g Google Drive), this is as far as you need to go. However if you're uploading to an HTTP server (e.g through an SFTP remote or locally), set `USE_RCLONE_LINK` to `no` and set `CUSTOM_LINK` to your domain and folder where the clips will be available.
+
+![image](https://github.com/user-attachments/assets/67c5c6b7-cf53-46ce-9d32-a719467ce9d2)
+
+
+   
+
+

--- a/bot.py
+++ b/bot.py
@@ -114,9 +114,9 @@ async def clip(interaction: discord.Interaction, link: str, seconds: int, rewind
                     await send_message(interaction, f"Download finished. Output file too large for Discord, compressing and uploading...")
                     await compress(clip_filename, seconds)
                     file = discord.File(clip_filename_compressed, filename=f"clip_{randomuuid}.mp4")
-                await interaction.followup.send(file=file)
-                os.remove(clip_filename)
-                os.remove(clip_filename_compressed)
+                    await interaction.followup.send(file=file)
+                    os.remove(clip_filename)
+                    os.remove(clip_filename_compressed)
                 if(os.getenv("USE_RCLONE") == "yes") or (os.getenv("USE_RCLONE") == "YES"):
                     await send_message(interaction, f"Download finished. Output file too large for Discord, uploading to remote rclone destination and sharing the link...")
                     rcloneremote = os.getenv("RCLONE_REMOTE_NAME")
@@ -137,9 +137,11 @@ async def clip(interaction: discord.Interaction, link: str, seconds: int, rewind
                     stdout, _ = await run_command(["rclone", "link", f"{rcloneremote}{clip_filename}"])
                     link = stdout.decode('utf-8').partition('\n')[0]
                     await send_message(interaction, f"Clip: {link}")
+                    os.remove(clip_filename)
                 if(os.getenv("USE_RCLONE_LINK") == "no" or os.getenv("USE_RCLONE_LINK") == "NO"):
                     custom_link = os.getenv("CUSTOM_LINK")
                     await send_message(interaction, f"Clip: {custom_link}{clip_filename}")
+                    os.remove(clip_filename)
             else:
                 await send_message(interaction, f"Download finished, uploading...")
                 file = discord.File(clip_filename, filename=f"clip_{randomuuid}.mp4")

--- a/bot.py
+++ b/bot.py
@@ -110,12 +110,36 @@ async def clip(interaction: discord.Interaction, link: str, seconds: int, rewind
             clip_filename = f"{randomuuid}.mp4"
             clip_filename_compressed = f"25MB_{randomuuid}.mp4"
             if (os.path.getsize(clip_filename) > 25165824):
-                await send_message(interaction, f"Download finished. Output file too large for Discord, compressing and uploading...")
-                await compress(clip_filename, seconds)
-                file = discord.File(clip_filename_compressed, filename=f"clip_{randomuuid}.mp4")
+                if(os.getenv("USE_RCLONE") == "no") or (os.getenv("USE_RCLONE") == "NO"):
+                    await send_message(interaction, f"Download finished. Output file too large for Discord, compressing and uploading...")
+                    await compress(clip_filename, seconds)
+                    file = discord.File(clip_filename_compressed, filename=f"clip_{randomuuid}.mp4")
                 await interaction.followup.send(file=file)
                 os.remove(clip_filename)
                 os.remove(clip_filename_compressed)
+                if(os.getenv("USE_RCLONE") == "yes") or (os.getenv("USE_RCLONE") == "YES"):
+                    await send_message(interaction, f"Download finished. Output file too large for Discord, uploading to remote rclone destination and sharing the link...")
+                    rcloneremote = os.getenv("RCLONE_REMOTE_NAME")
+                    rclonecommand = [
+                    "rclone",
+                    "copyto", clip_filename, f"{rcloneremote}{clip_filename}", f"-P"
+                    ]
+                    try:
+                        stdout, stderr = await run_command(rclonecommand)
+                        print(f"Rclone stdout: {stdout}")
+                        print(f"Rclone stderr: {stderr}")
+
+                    except Exception as e:
+                        last_line = str(e).strip().split('\n')[-1]
+                        await send_message(f"Failed to upload: {str(last_line)}")
+                        print(f"Failed to upload: {str(last_line)}")
+                if(os.getenv("USE_RCLONE_LINK") == "yes" or os.getenv("USE_RCLONE_LINK") == "YES"):
+                    stdout, _ = await run_command(["rclone", "link", f"{rcloneremote}{clip_filename}"])
+                    link = stdout.decode('utf-8').partition('\n')[0]
+                    await send_message(interaction, f"Clip: {link}")
+                if(os.getenv("USE_RCLONE_LINK") == "no" or os.getenv("USE_RCLONE_LINK") == "NO"):
+                    custom_link = os.getenv("CUSTOM_LINK")
+                    await send_message(interaction, f"Clip: {custom_link}{clip_filename}")
             else:
                 await send_message(interaction, f"Download finished, uploading...")
                 file = discord.File(clip_filename, filename=f"clip_{randomuuid}.mp4")

--- a/bot.py
+++ b/bot.py
@@ -135,7 +135,7 @@ async def clip(interaction: discord.Interaction, link: str, seconds: int, rewind
                         print(f"Failed to upload: {str(last_line)}")
                 if(os.getenv("USE_RCLONE_LINK") == "yes" or os.getenv("USE_RCLONE_LINK") == "YES"):
                     stdout, _ = await run_command(["rclone", "link", f"{rcloneremote}{clip_filename}"])
-                    link = stdout.decode('utf-8').partition('\n')[0]
+                    link = stdout.partition('\n')[0]
                     await send_message(interaction, f"Clip: {link}")
                     os.remove(clip_filename)
                 if(os.getenv("USE_RCLONE_LINK") == "no" or os.getenv("USE_RCLONE_LINK") == "NO"):

--- a/compress.py
+++ b/compress.py
@@ -34,7 +34,6 @@ async def compress(inputfile, duration):
         print(f"FFmpeg stdout: {stdout}")
         print(f"FFmpeg stderr: {stderr}")
 
-        # Check if the output file exists
         if not os.path.exists(outputfile):
             raise Exception("Output file was not created")
 


### PR DESCRIPTION
If a file is above 25MB in size, instead of using compression to make it smaller that can take up a huge amount of time on some low-end systems, use a remote rclone destination and a link for the clip instead. This would speed up stuff tremendously in those scenarios